### PR TITLE
Add option to skip plotting processed entirely

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -813,6 +813,9 @@ process Plot_Mean_Std_Per_Point {
     output:
     set sid, "*.png"
 
+    when:
+    !params.skip_plotting
+
     script:
     def json_str = JsonOutput.toJson(params.colors)
     """
@@ -829,6 +832,9 @@ process Plot_Lesions_Per_Point {
 
     output:
     set sid, "*.png"
+
+    when:
+    !params.skip_plotting
 
     script:
     def json_str = JsonOutput.toJson(params.colors)
@@ -1072,6 +1078,9 @@ process Plot_Population_Mean_Std_Per_Point {
 
     output:
     file "*.png"
+
+    when:
+    !params.skip_plotting
 
     script:
     def json_str = JsonOutput.toJson(params.colors)

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,6 +18,7 @@ params {
     use_provided_centroids=true
     skip_projection_endpoints_metrics=true
     skip_tract_profiles=false
+    skip_plotting=true
     bundle_suffix_to_remove='_cleaned'
 
     colors=["AC":"0x02d983",


### PR DESCRIPTION
The `skip_plotting` param is set to `true` by default.